### PR TITLE
Up to 6.10.11 & enable landlock

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -7,7 +7,7 @@ pkgname=(
   "${pkgbase}"
   "${pkgbase}-headers"
 )
-pkgver='6.10.10'
+pkgver='6.10.11'
 pkgrel=1
 arch=('aarch64')
 url="https://kernel.org"
@@ -25,9 +25,9 @@ source=(
   'config'
 )
 sha256sums=(
-  'e687e735b5eb9efb6d67b42433c93fc9118106a995514f062652873b5e809bcd'
+  'fb4da046f8c185159f4537ded887a30acc69d91c555a0ff7fabc4520f59a3096'
   "${_sha256_patch}"
-  '623d4e82816f0a20e9cc8e1cc7a7b429cea3a9f57ea506f438d3ba12116637c1'
+  'cc3b619dbd2b20b6c3cfd1ad283112eb26f6441163530f218ec7d2087f948372'
 )
 
 prepare() {

--- a/config
+++ b/config
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm64 6.10.10 Kernel Configuration
+# Linux/arm64 6.10.11 Kernel Configuration
 #
 CONFIG_CC_VERSION_TEXT="gcc (GCC) 14.1.1 20240507"
 CONFIG_CC_IS_GCC=y
@@ -8619,7 +8619,7 @@ CONFIG_SECURITY_APPARMOR_PARANOID_LOAD=y
 # CONFIG_SECURITY_YAMA is not set
 # CONFIG_SECURITY_SAFESETID is not set
 # CONFIG_SECURITY_LOCKDOWN_LSM is not set
-# CONFIG_SECURITY_LANDLOCK is not set
+CONFIG_SECURITY_LANDLOCK=y
 CONFIG_INTEGRITY=y
 # CONFIG_INTEGRITY_SIGNATURE is not set
 CONFIG_INTEGRITY_AUDIT=y
@@ -8629,7 +8629,7 @@ CONFIG_INTEGRITY_AUDIT=y
 # CONFIG_DEFAULT_SECURITY_SELINUX is not set
 # CONFIG_DEFAULT_SECURITY_APPARMOR is not set
 CONFIG_DEFAULT_SECURITY_DAC=y
-CONFIG_LSM="yama,loadpin,safesetid,integrity,selinux,smack,tomoyo,apparmor"
+CONFIG_LSM="landlock,yama,loadpin,safesetid,integrity,selinux,smack,tomoyo,apparmor"
 
 #
 # Kernel hardening options


### PR DESCRIPTION
- Pacman 7 added a sandbox for the downloaduser. Therefore, ```CONFIG_SECURITY_LANDLOCK=y``` should be set, otherwise warning ```error: restricting filesystem access failed because landlock is not supported by the kernel!``` will appear.

```
╰─❯ sudo pacman -Syu
:: Synchronizing package databases...
 core is up to date
 extra is up to date
 alarm is up to date
 aur is up to date
 7Ji is up to date
 archlinuxcn is up to date
error: restricting filesystem access failed because landlock is not supported by the kernel!
:: Starting full system upgrade...
 there is nothing to do
```

- References: https://docs.kernel.org/userspace-api/landlock.html