### PR TITLE
Update to 6.13

### DIFF
--- a/.SRCINFO
+++ b/.SRCINFO
@@ -1,5 +1,5 @@
 pkgbase = linux-aarch64-7ji
-	pkgver = 6.12.10
+	pkgver = 6.13
 	pkgrel = 1
 	url = https://kernel.org
 	arch = aarch64
@@ -10,12 +10,12 @@ pkgbase = linux-aarch64-7ji
 	makedepends = uboot-tools
 	makedepends = pahole
 	options = !strip
-	source = https://cdn.kernel.org/pub/linux/kernel/v6.x/linux-6.12.10.tar.xz
+	source = https://cdn.kernel.org/pub/linux/kernel/v6.x/linux-6.13.tar.xz
 	source = 0001-rebase-local-changes-to-v6.11.patch.xz::https://github.com/7Ji-PKGBUILDs/linux-aarch64-7ji/releases/download/assets/sha256-44e5bc7e7d5a58c6e462ae53be86d80d45dcaa046e57369966d8648f39b41461-0001-rebase-local-changes-to-v6.11.patch.xz
 	source = config
-	sha256sums = 4a516e5ed748537a73cb42ec47fbbeb6df8b1298e8892c29c0e91de79095b297
+	sha256sums = e79dcc6eb86695c6babfb07c2861912b635d5075c6cd1cd0567d1ea155f80d6e
 	sha256sums = 44e5bc7e7d5a58c6e462ae53be86d80d45dcaa046e57369966d8648f39b41461
-	sha256sums = d3f0898f3b7805d9d22558d1a8d79266ba2ba4bf6d9d9569d2245b72f1b26938
+	sha256sums = c6902d0d97adb1b634f73531bf8c27f6c5009d4c4939fb364773d4233e6247ff
 
 pkgname = linux-aarch64-7ji
 	pkgdesc = The Linux Kernel and module - almost mainline but with 7Ji's patches, for Amlogic, Rockchip and virt

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -7,7 +7,7 @@ pkgname=(
   "${pkgbase}"
   "${pkgbase}-headers"
 )
-pkgver='6.12.11'
+pkgver='6.13'
 pkgrel=1
 arch=('aarch64')
 url="https://kernel.org"
@@ -25,9 +25,9 @@ source=(
   'config'
 )
 sha256sums=(
-  '475172fdbd87a153f123a57952672e773bdb6daf5b58a417d1a5e419fcfeec49'
+  'e79dcc6eb86695c6babfb07c2861912b635d5075c6cd1cd0567d1ea155f80d6e'
   "${_sha256_patch}"
-  '1ed7a72518451222b3309a2dc2cd8346d21045b405299d2b5080617416603be3'
+  'c6902d0d97adb1b634f73531bf8c27f6c5009d4c4939fb364773d4233e6247ff'
 )
 
 prepare() {

--- a/config
+++ b/config
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm64 6.12.11 Kernel Configuration
+# Linux/arm64 6.13 Kernel Configuration
 #
 CONFIG_CC_VERSION_TEXT="gcc (GCC) 14.1.1 20240507"
 CONFIG_CC_IS_GCC=y


### PR DESCRIPTION
Latest stable linux version (6.13) seems to have [fixed the SATA/nVME getting undetected issue](https://forum.radxa.com/t/mainline-kernel-now-working-on-rock-5-itx-as-a-server/24531) in Rock 5 ITX boards

Successfully built and ran the 6.13 kernel with this patch on both my Rock 5 ITX and Rock 5B boards and it works great so far.